### PR TITLE
Add terminal Blackjack card game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# testes
+# Jogo de Cartas - Blackjack
+
+Este projeto contém um jogo de cartas estilo Blackjack jogável diretamente no
+terminal. O jogo está disponível em português e oferece dois modos:
+
+- **Interativo**: você toma decisões digitando `c` (comprar carta) ou `p`
+  (parar).
+- **Demonstração**: o computador joga automaticamente utilizando uma estratégia
+  simples (comprar até atingir 17 pontos).
+
+## Pré-requisitos
+
+- Python 3.10 ou superior.
+
+## Como jogar
+
+Execute no terminal, a partir da raiz do repositório:
+
+```bash
+python -m card_game
+```
+
+Você poderá jogar quantas rodadas quiser. Para sair, responda `n` quando
+perguntado se deseja jogar novamente.
+
+## Modo demonstração
+
+Para assistir rodadas automáticas, execute:
+
+```bash
+python -m card_game --demo --rodadas 5 --seed 42
+```
+
+- `--rodadas` define quantas rodadas serão jogadas.
+- `--seed` opcionalmente fixa a semente do gerador aleatório para tornar o
+  resultado reproduzível.

--- a/card_game/__init__.py
+++ b/card_game/__init__.py
@@ -1,0 +1,5 @@
+"""Pacote contendo um jogo de cartas estilo Blackjack."""
+
+from .blackjack import BlackjackGame
+
+__all__ = ["BlackjackGame"]

--- a/card_game/__main__.py
+++ b/card_game/__main__.py
@@ -1,0 +1,7 @@
+"""Ponto de entrada para executar o jogo via ``python -m card_game``."""
+
+from .blackjack import main
+
+
+if __name__ == "__main__":  # pragma: no cover - entrada de módulo
+    main()

--- a/card_game/blackjack.py
+++ b/card_game/blackjack.py
@@ -1,0 +1,147 @@
+"""Implementação de um jogo simples de Blackjack."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass
+from typing import Callable, Iterable, Iterator, Sequence
+
+from .cards import Deck, Hand
+
+DecisionSource = Callable[[Hand], str] | Iterable[str] | None
+
+
+@dataclass
+class RoundResult:
+    """Resultado de uma rodada."""
+
+    player_hand: Hand
+    dealer_hand: Hand
+    outcome: str
+    explanation: str
+
+
+class BlackjackGame:
+    """Controla a lógica de uma partida de Blackjack."""
+
+    def __init__(self, *, seed: int | None = None) -> None:
+        self._rng = random.Random(seed)
+        self._deck = Deck(rng=self._rng)
+
+    def _fresh_hands(self) -> tuple[Hand, Hand]:
+        if self._deck.remaining() < 15:
+            self._deck.reset()
+        player = Hand(self._deck.deal(2))
+        dealer = Hand(self._deck.deal(2))
+        return player, dealer
+
+    def _dealer_turn(self, hand: Hand) -> None:
+        while hand.value() < 17:
+            hand.add(self._deck.draw())
+
+    def _determine_winner(self, player: Hand, dealer: Hand) -> tuple[str, str]:
+        if player.is_bust():
+            return "dealer", "Você estourou 21. O dealer vence."
+        if dealer.is_bust():
+            return "player", "O dealer estourou 21. Você vence!"
+        if player.value() > dealer.value():
+            return "player", "Sua mão é maior. Você vence!"
+        if player.value() < dealer.value():
+            return "dealer", "O dealer tem mais pontos. Você perde."
+        return "push", "Empate! Ambos têm o mesmo valor."
+
+    def _decision_iterator(self, player: Hand, source: DecisionSource) -> Iterator[str]:
+        if source is None:
+            while True:
+                yield "c" if player.value() < 17 else "p"
+        elif callable(source):
+            while True:
+                yield source(player)
+        else:
+            iterator = iter(source)
+            for decision in iterator:
+                yield decision
+            while True:
+                yield "p"
+
+    def play_round(self, decisions: DecisionSource = None) -> RoundResult:
+        """Executa uma rodada de Blackjack.
+
+        ``decisions`` pode ser ``None`` (estratégia automática simples), um
+        iterável de decisões pré-determinadas ou uma função que recebe a mão do
+        jogador e retorna "c" (comprar carta) ou "p" (parar).
+        """
+
+        player, dealer = self._fresh_hands()
+
+        if player.is_blackjack() and dealer.is_blackjack():
+            return RoundResult(player, dealer, "push", "Blackjack duplo! Empate.")
+        if player.is_blackjack():
+            return RoundResult(player, dealer, "player", "Blackjack natural! Você vence.")
+        if dealer.is_blackjack():
+            return RoundResult(player, dealer, "dealer", "O dealer tem Blackjack.")
+
+        for decision in self._decision_iterator(player, decisions):
+            if decision.lower().startswith("c"):
+                player.add(self._deck.draw())
+                if player.is_bust():
+                    return RoundResult(player, dealer, "dealer", "Você estourou 21. O dealer vence.")
+            elif decision.lower().startswith("p"):
+                break
+
+        self._dealer_turn(dealer)
+        outcome, explanation = self._determine_winner(player, dealer)
+        return RoundResult(player, dealer, outcome, explanation)
+
+    def play_interactive(self) -> None:
+        """Loop interativo para jogar via terminal."""
+
+        print("Bem-vindo ao Blackjack!")
+        keep_playing = True
+        while keep_playing:
+            result = self.play_round(self._interactive_decision)
+            print("\nSuas cartas:", result.player_hand.formatted())
+            print("Valor:", result.player_hand.value())
+            print("Mão do dealer:", result.dealer_hand.formatted())
+            print("Valor do dealer:", result.dealer_hand.value())
+            print(result.explanation)
+            again = input("Jogar novamente? (s/n): ").strip().lower()
+            keep_playing = again == "s"
+        print("Obrigado por jogar!")
+
+    def _interactive_decision(self, hand: Hand) -> str:
+        while True:
+            choice = input("Digite 'c' para carta ou 'p' para parar: ").strip().lower()
+            if choice in {"c", "p"}:
+                return choice
+            print("Opção inválida. Tente novamente.")
+
+
+def run_demo(rounds: int, seed: int | None) -> None:
+    game = BlackjackGame(seed=seed)
+    for number in range(1, rounds + 1):
+        result = game.play_round()
+        print(f"Rodada {number}")
+        print("Jogador:", result.player_hand.formatted(), f"({result.player_hand.value()} pontos)")
+        print("Dealer:", result.dealer_hand.formatted(), f"({result.dealer_hand.value()} pontos)")
+        print(result.explanation)
+        print("-" * 40)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Jogo de cartas Blackjack no terminal.")
+    parser.add_argument("--demo", action="store_true", help="Executa rodadas automáticas de demonstração.")
+    parser.add_argument("--rodadas", type=int, default=3, help="Quantidade de rodadas na demonstração.")
+    parser.add_argument("--seed", type=int, default=None, help="Semente para o gerador aleatório.")
+    args = parser.parse_args(argv)
+
+    if args.demo:
+        run_demo(args.rodadas, args.seed)
+    else:
+        game = BlackjackGame(seed=args.seed)
+        game.play_interactive()
+
+
+if __name__ == "__main__":  # pragma: no cover - entrada de módulo
+    main()

--- a/card_game/cards.py
+++ b/card_game/cards.py
@@ -1,0 +1,117 @@
+"""Componentes básicos de cartas utilizados no jogo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+import random
+
+SUITS = ["Copas", "Ouros", "Paus", "Espadas"]
+RANKS = [
+    ("A", 1),
+    ("2", 2),
+    ("3", 3),
+    ("4", 4),
+    ("5", 5),
+    ("6", 6),
+    ("7", 7),
+    ("8", 8),
+    ("9", 9),
+    ("10", 10),
+    ("J", 10),
+    ("Q", 10),
+    ("K", 10),
+]
+
+
+@dataclass(frozen=True)
+class Card:
+    """Representa uma carta de baralho."""
+
+    rank: str
+    suit: str
+
+    @property
+    def value(self) -> int:
+        """Valor base da carta considerando regras do Blackjack."""
+
+        for r, value in RANKS:
+            if r == self.rank:
+                return value
+        raise ValueError(f"Rank desconhecido: {self.rank}")
+
+    def __str__(self) -> str:  # pragma: no cover - método trivial
+        return f"{self.rank} de {self.suit}"
+
+
+class Deck:
+    """Baralho padrão com 52 cartas."""
+
+    def __init__(self, *, rng: random.Random | None = None) -> None:
+        self._rng = rng or random.Random()
+        self._cards: List[Card] = []
+        self.reset()
+
+    def reset(self) -> None:
+        """Recria um baralho completo e o embaralha."""
+
+        self._cards = [Card(rank, suit) for suit in SUITS for rank, _ in RANKS]
+        self.shuffle()
+
+    def shuffle(self) -> None:
+        """Embaralha o baralho."""
+
+        self._rng.shuffle(self._cards)
+
+    def draw(self) -> Card:
+        """Retira uma carta do topo do baralho."""
+
+        if not self._cards:
+            raise RuntimeError("O baralho acabou. Reinicie a partida.")
+        return self._cards.pop()
+
+    def remaining(self) -> int:
+        """Quantidade de cartas restantes."""
+
+        return len(self._cards)
+
+    def deal(self, quantity: int) -> List[Card]:
+        """Retorna múltiplas cartas de uma só vez."""
+
+        if quantity < 0:
+            raise ValueError("A quantidade deve ser positiva.")
+        return [self.draw() for _ in range(quantity)]
+
+
+class Hand:
+    """Representa uma mão de Blackjack."""
+
+    def __init__(self, cards: Iterable[Card] | None = None) -> None:
+        self.cards: List[Card] = list(cards or [])
+
+    def add(self, card: Card) -> None:
+        self.cards.append(card)
+
+    def value(self) -> int:
+        """Calcula o melhor valor possível para a mão."""
+
+        total = sum(card.value for card in self.cards)
+        aces = sum(1 for card in self.cards if card.rank == "A")
+        while aces > 0 and total + 10 <= 21:
+            total += 10
+            aces -= 1
+        return total
+
+    def is_blackjack(self) -> bool:
+        return len(self.cards) == 2 and self.value() == 21
+
+    def is_bust(self) -> bool:
+        return self.value() > 21
+
+    def formatted(self, hide_first: bool = False) -> str:
+        """Representação textual da mão."""
+
+        if hide_first and self.cards:
+            hidden = ["[CARTA VIRADA]"] + [str(card) for card in self.cards[1:]]
+            return ", ".join(hidden)
+        return ", ".join(str(card) for card in self.cards)


### PR DESCRIPTION
## Summary
- add a Python Blackjack card game with reusable deck and hand abstractions
- provide an interactive terminal interface and automatic demo mode
- document usage instructions and ignore Python cache files

## Testing
- python -m card_game --demo --rodadas 2 --seed 1

------
https://chatgpt.com/codex/tasks/task_e_68e5cfae51d0832d8bdc85422f4c33c4